### PR TITLE
Replacing sycl::accessor<... target:local> with sycl::local_accessor<...>

### DIFF
--- a/dpcpp/kernel1.dp.cpp
+++ b/dpcpp/kernel1.dp.cpp
@@ -76,13 +76,10 @@ void gpu_calc_initpop(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                sycl::accessor<sycl::float3, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    calc_coords_acc_ct1(
-                        sycl::range<1>(/*256*/ MAX_NUM_OF_ATOMS), cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    sFloatAccumulator_acc_ct1(cgh);
+                //sycl::accessor<sycl::float3, 1, sycl::access::mode::read_write, sycl::access::target::local> calc_coords_acc_ct1(sycl::range<1>(/*256*/ MAX_NUM_OF_ATOMS), cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);
+                sycl::local_accessor<sycl::float3, 1> calc_coords_acc_ct1(sycl::range<1>(/*256*/ MAX_NUM_OF_ATOMS), cgh);
+                sycl::local_accessor<float, 0> sFloatAccumulator_acc_ct1(cgh);
 
                 cgh.parallel_for(
                     sycl::nd_range<3>(sycl::range<3>(1, 1, blocks) *

--- a/dpcpp/kernel1.dp.cpp
+++ b/dpcpp/kernel1.dp.cpp
@@ -76,8 +76,6 @@ void gpu_calc_initpop(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                //sycl::accessor<sycl::float3, 1, sycl::access::mode::read_write, sycl::access::target::local> calc_coords_acc_ct1(sycl::range<1>(/*256*/ MAX_NUM_OF_ATOMS), cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);
                 sycl::local_accessor<sycl::float3, 1> calc_coords_acc_ct1(sycl::range<1>(/*256*/ MAX_NUM_OF_ATOMS), cgh);
                 sycl::local_accessor<float, 0> sFloatAccumulator_acc_ct1(cgh);
 

--- a/dpcpp/kernel2.dp.cpp
+++ b/dpcpp/kernel2.dp.cpp
@@ -71,7 +71,6 @@ void gpu_sum_evals(uint32_t blocks, uint32_t threadsPerBlock)
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> sSum_evals_acc_ct1(cgh);
                 sycl::local_accessor<int, 0> sSum_evals_acc_ct1(cgh);
 
                 cgh.parallel_for(

--- a/dpcpp/kernel2.dp.cpp
+++ b/dpcpp/kernel2.dp.cpp
@@ -71,9 +71,8 @@ void gpu_sum_evals(uint32_t blocks, uint32_t threadsPerBlock)
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    sSum_evals_acc_ct1(cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> sSum_evals_acc_ct1(cgh);
+                sycl::local_accessor<int, 0> sSum_evals_acc_ct1(cgh);
 
                 cgh.parallel_for(
                     sycl::nd_range<3>(sycl::range<3>(1, 1, blocks) *

--- a/dpcpp/kernel3.dp.cpp
+++ b/dpcpp/kernel3.dp.cpp
@@ -386,15 +386,6 @@ void gpu_perform_LS(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                //sycl::accessor<uint8_t, 1, sycl::access::mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> rho_acc_ct1(cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> cons_succ_acc_ct1(cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> cons_fail_acc_ct1(cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> iteration_cnt_acc_ct1(cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> evaluation_cnt_acc_ct1(cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> offspring_energy_acc_ct1(cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> entity_id_acc_ct1(cgh);
                 sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
                 sycl::local_accessor<float, 0> rho_acc_ct1(cgh);
                 sycl::local_accessor<int, 0> cons_succ_acc_ct1(cgh);

--- a/dpcpp/kernel3.dp.cpp
+++ b/dpcpp/kernel3.dp.cpp
@@ -386,33 +386,24 @@ void gpu_perform_LS(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                sycl::accessor<uint8_t, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    rho_acc_ct1(cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    cons_succ_acc_ct1(cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    cons_fail_acc_ct1(cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    iteration_cnt_acc_ct1(cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    evaluation_cnt_acc_ct1(cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    offspring_energy_acc_ct1(cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    sFloatAccumulator_acc_ct1(cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    entity_id_acc_ct1(cgh);
+                //sycl::accessor<uint8_t, 1, sycl::access::mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> rho_acc_ct1(cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> cons_succ_acc_ct1(cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> cons_fail_acc_ct1(cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> iteration_cnt_acc_ct1(cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> evaluation_cnt_acc_ct1(cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> offspring_energy_acc_ct1(cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> entity_id_acc_ct1(cgh);
+                sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
+                sycl::local_accessor<float, 0> rho_acc_ct1(cgh);
+                sycl::local_accessor<int, 0> cons_succ_acc_ct1(cgh);
+                sycl::local_accessor<int, 0> cons_fail_acc_ct1(cgh);
+                sycl::local_accessor<int, 0> iteration_cnt_acc_ct1(cgh);
+                sycl::local_accessor<int, 0> evaluation_cnt_acc_ct1(cgh);
+                sycl::local_accessor<float, 0> offspring_energy_acc_ct1(cgh);
+                sycl::local_accessor<float, 0> sFloatAccumulator_acc_ct1(cgh);
+                sycl::local_accessor<int, 0> entity_id_acc_ct1(cgh);
 
                 cgh.parallel_for(
                     sycl::nd_range<3>(sycl::range<3>(1, 1, blocks) *

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -428,38 +428,26 @@ void gpu_gen_and_eval_newpops(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                sycl::accessor<float, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    offspring_genotype_acc_ct1(
-                        sycl::range<1>(64 /*ACTUAL_GENOTYPE_LENGTH*/), cgh);
-                sycl::accessor<int, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    parent_candidates_acc_ct1(sycl::range<1>(4), cgh);
-                sycl::accessor<float, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    candidate_energies_acc_ct1(sycl::range<1>(4), cgh);
-                sycl::accessor<int, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    parents_acc_ct1(sycl::range<1>(2), cgh);
-                sycl::accessor<int, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    covr_point_acc_ct1(sycl::range<1>(2), cgh);
-                sycl::accessor<float, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    randnums_acc_ct1(sycl::range<1>(10), cgh);
-                sycl::accessor<float, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    sBestEnergy_acc_ct1(sycl::range<1>(32), cgh);
-                sycl::accessor<int, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    sBestID_acc_ct1(sycl::range<1>(32), cgh);
-                sycl::accessor<sycl::float3, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    calc_coords_acc_ct1(
-                        sycl::range<1>(256 /*MAX_NUM_OF_ATOMS*/), cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    sFloatAccumulator_acc_ct1(cgh);
+                //sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::local> offspring_genotype_acc_ct1(sycl::range<1>(64 /*ACTUAL_GENOTYPE_LENGTH*/), cgh);
+                //sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> parent_candidates_acc_ct1(sycl::range<1>(4), cgh);
+                //sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::local> candidate_energies_acc_ct1(sycl::range<1>(4), cgh);
+                //sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> parents_acc_ct1(sycl::range<1>(2), cgh);
+                //sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> covr_point_acc_ct1(sycl::range<1>(2), cgh);
+                //sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::local> randnums_acc_ct1(sycl::range<1>(10), cgh);
+                //sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::local> sBestEnergy_acc_ct1(sycl::range<1>(32), cgh);
+                //sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> sBestID_acc_ct1(sycl::range<1>(32), cgh);
+                //sycl::accessor<sycl::float3, 1, sycl::access::mode::read_write, sycl::access::target::local> calc_coords_acc_ct1(sycl::range<1>(256 /*MAX_NUM_OF_ATOMS*/), cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);  
+                sycl::local_accessor<float, 1> offspring_genotype_acc_ct1(sycl::range<1>(64 /*ACTUAL_GENOTYPE_LENGTH*/), cgh);
+                sycl::local_accessor<int, 1> parent_candidates_acc_ct1(sycl::range<1>(4), cgh);
+                sycl::local_accessor<float, 1> candidate_energies_acc_ct1(sycl::range<1>(4), cgh);
+                sycl::local_accessor<int, 1> parents_acc_ct1(sycl::range<1>(2), cgh);
+                sycl::local_accessor<int, 1> covr_point_acc_ct1(sycl::range<1>(2), cgh);
+                sycl::local_accessor<float, 1> randnums_acc_ct1(sycl::range<1>(10), cgh);
+                sycl::local_accessor<float, 1> sBestEnergy_acc_ct1(sycl::range<1>(32), cgh);
+                sycl::local_accessor<int, 1> sBestID_acc_ct1(sycl::range<1>(32), cgh);
+                sycl::local_accessor<sycl::float3, 1> calc_coords_acc_ct1(sycl::range<1>(256 /*MAX_NUM_OF_ATOMS*/), cgh);
+                sycl::local_accessor<float, 0> sFloatAccumulator_acc_ct1(cgh);
 
                 cgh.parallel_for(
                     sycl::nd_range<3>(sycl::range<3>(1, 1, blocks) *

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -428,16 +428,6 @@ void gpu_gen_and_eval_newpops(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                //sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::local> offspring_genotype_acc_ct1(sycl::range<1>(64 /*ACTUAL_GENOTYPE_LENGTH*/), cgh);
-                //sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> parent_candidates_acc_ct1(sycl::range<1>(4), cgh);
-                //sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::local> candidate_energies_acc_ct1(sycl::range<1>(4), cgh);
-                //sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> parents_acc_ct1(sycl::range<1>(2), cgh);
-                //sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> covr_point_acc_ct1(sycl::range<1>(2), cgh);
-                //sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::local> randnums_acc_ct1(sycl::range<1>(10), cgh);
-                //sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::local> sBestEnergy_acc_ct1(sycl::range<1>(32), cgh);
-                //sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local> sBestID_acc_ct1(sycl::range<1>(32), cgh);
-                //sycl::accessor<sycl::float3, 1, sycl::access::mode::read_write, sycl::access::target::local> calc_coords_acc_ct1(sycl::range<1>(256 /*MAX_NUM_OF_ATOMS*/), cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);  
                 sycl::local_accessor<float, 1> offspring_genotype_acc_ct1(sycl::range<1>(64 /*ACTUAL_GENOTYPE_LENGTH*/), cgh);
                 sycl::local_accessor<int, 1> parent_candidates_acc_ct1(sycl::range<1>(4), cgh);
                 sycl::local_accessor<float, 1> candidate_energies_acc_ct1(sycl::range<1>(4), cgh);

--- a/dpcpp/kernel_ad.dp.cpp
+++ b/dpcpp/kernel_ad.dp.cpp
@@ -466,27 +466,20 @@ void gpu_gradient_minAD(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                sycl::accessor<uint8_t, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    entity_id_acc_ct1(cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    best_energy_acc_ct1(cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    sFloatAccumulator_acc_ct1(cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    rho_acc_ct1(cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    cons_succ_acc_ct1(cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    cons_fail_acc_ct1(cgh);
+                //sycl::accessor<uint8_t, 1, sycl::access::mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> entity_id_acc_ct1(cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> best_energy_acc_ct1(cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> rho_acc_ct1(cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> cons_succ_acc_ct1(cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> cons_fail_acc_ct1(cgh); 
+                sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
+                sycl::local_accessor<int, 0> entity_id_acc_ct1(cgh);
+                sycl::local_accessor<float, 0> best_energy_acc_ct1(cgh);
+                sycl::local_accessor<float, 0> sFloatAccumulator_acc_ct1(cgh);
+                sycl::local_accessor<float, 0> rho_acc_ct1(cgh);
+                sycl::local_accessor<int, 0> cons_succ_acc_ct1(cgh);
+                sycl::local_accessor<int, 0> cons_fail_acc_ct1(cgh);
 
                 cgh.parallel_for(
                     sycl::nd_range<3>(sycl::range<3>(1, 1, blocks) *

--- a/dpcpp/kernel_ad.dp.cpp
+++ b/dpcpp/kernel_ad.dp.cpp
@@ -466,13 +466,6 @@ void gpu_gradient_minAD(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                //sycl::accessor<uint8_t, 1, sycl::access::mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> entity_id_acc_ct1(cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> best_energy_acc_ct1(cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> rho_acc_ct1(cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> cons_succ_acc_ct1(cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> cons_fail_acc_ct1(cgh); 
                 sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
                 sycl::local_accessor<int, 0> entity_id_acc_ct1(cgh);
                 sycl::local_accessor<float, 0> best_energy_acc_ct1(cgh);

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -469,10 +469,6 @@ void gpu_gradient_minAdam(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                //sycl::accessor<uint8_t, 1, sycl::access::mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
-                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> entity_id_acc_ct1(cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> best_energy_acc_ct1(cgh);
-                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);
                 sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
                 sycl::local_accessor<int, 0> entity_id_acc_ct1(cgh);
                 sycl::local_accessor<float, 0> best_energy_acc_ct1(cgh);

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -469,18 +469,14 @@ void gpu_gradient_minAdam(
 
                 auto cData_ptr_ct1 = cData.get_ptr();
 
-                sycl::accessor<uint8_t, 1, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
-                sycl::accessor<int, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    entity_id_acc_ct1(cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    best_energy_acc_ct1(cgh);
-                sycl::accessor<float, 0, sycl::access::mode::read_write,
-                               sycl::access::target::local>
-                    sFloatAccumulator_acc_ct1(cgh);
+                //sycl::accessor<uint8_t, 1, sycl::access::mode::read_write, sycl::access::target::local> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
+                //sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::local> entity_id_acc_ct1(cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> best_energy_acc_ct1(cgh);
+                //sycl::accessor<float, 0, sycl::access::mode::read_write, sycl::access::target::local> sFloatAccumulator_acc_ct1(cgh);
+                sycl::local_accessor<uint8_t, 1> dpct_local_acc_ct1(sycl::range<1>(sz_shared), cgh);
+                sycl::local_accessor<int, 0> entity_id_acc_ct1(cgh);
+                sycl::local_accessor<float, 0> best_energy_acc_ct1(cgh);
+                sycl::local_accessor<float, 0> sFloatAccumulator_acc_ct1(cgh);
 
                 cgh.parallel_for(
                     sycl::nd_range<3>(sycl::range<3>(1, 1, blocks) *


### PR DESCRIPTION
This code change removes compilation warnings due to deprecated declarations.